### PR TITLE
Remove an unnecessary pragma suppressing orphan instance warnings

### DIFF
--- a/src/Numeric/Estimator/Model/Symbolic.hs
+++ b/src/Numeric/Estimator/Model/Symbolic.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 {- |
 Description: Support for purely symbolic models
 


### PR DESCRIPTION
I was exploring and found this minor cleanup.