### PR TITLE
Atmos

### DIFF
--- a/estimator.cabal
+++ b/estimator.cabal
@@ -54,7 +54,8 @@ library
                        distributive >=0.4,
                        lens >=4.6,
                        linear >=1.16 && <1.17,
-                       reflection >=1.5
+                       reflection >=1.5,
+                       atmos >= 0.2
   default-language:    Haskell2010
   ghc-options:         -Wall
   if flag(werror)

--- a/src/Numeric/Estimator/Model/Pressure.hs
+++ b/src/Numeric/Estimator/Model/Pressure.hs
@@ -1,26 +1,17 @@
 {- |
-Description: Simplified atmosphere model
-
-This module implements the
+Description: This module implements the
 <http://en.wikipedia.org/wiki/U.S._Standard_Atmosphere#1976_version 1976 U.S. Standard Atmosphere>,
-but is only valid for altitudes from sea level to 11km.
+for altitudes from sea level to 86km.
 -}
 
 module Numeric.Estimator.Model.Pressure (pressureToHeight, heightToPressure) where
 
-basePressure, baseTemperature, lapseRate, baseAltitude, airGasConstant, g_0, airMass :: Floating a => a
-basePressure = 101325 -- Pascals
-baseTemperature = 288.15 -- K
-lapseRate = -0.0065 -- K/m
-baseAltitude = 0 -- m
-airGasConstant = 8.31432 --  N-m/mol-K
-g_0 = 9.80665 -- m/s/s
-airMass = 0.0289644 -- kg/mol
+import Atmosphere
 
 -- | Given a barometric pressure measurement in Pascals, return altitude in meters.
-pressureToHeight :: Floating a => a -> a
-pressureToHeight pressure = (baseAltitude * lapseRate + baseTemperature / ((pressure / basePressure) ** (airGasConstant * lapseRate / (g_0 * airMass))) - baseTemperature) / lapseRate
+pressureToHeight :: (Floating a, Ord a) => a -> a
+pressureToHeight = atmosPressure . siAtmosphere
 
 -- | Given altitude in meters, return a barometric pressure measurement in Pascals.
-heightToPressure :: Floating a => a -> a
-heightToPressure height = basePressure * (baseTemperature / (baseTemperature + lapseRate * (height - baseAltitude))) ** (g_0 * airMass / (airGasConstant * lapseRate))
+heightToPressure :: (Floating a, Ord a) => a -> a
+heightToPressure = siAltitudeFromPressure

--- a/src/Numeric/Estimator/Model/Pressure.hs
+++ b/src/Numeric/Estimator/Model/Pressure.hs
@@ -10,8 +10,8 @@ import Atmosphere
 
 -- | Given a barometric pressure measurement in Pascals, return altitude in meters.
 pressureToHeight :: (Floating a, Ord a) => a -> a
-pressureToHeight = atmosPressure . siAtmosphere
+pressureToHeight = siAltitudeFromPressure
 
 -- | Given altitude in meters, return a barometric pressure measurement in Pascals.
 heightToPressure :: (Floating a, Ord a) => a -> a
-heightToPressure = siAltitudeFromPressure
+heightToPressure = atmosPressure . siAtmosphere

--- a/src/Numeric/Estimator/Model/SensorFusion.hs
+++ b/src/Numeric/Estimator/Model/SensorFusion.hs
@@ -274,7 +274,7 @@ processModel dt (AugmentState state dist) = AugmentState state' $ pure 0
 
 -- | Compute the local air pressure from the state vector. Useful as a
 -- measurement model for a pressure sensor.
-statePressure :: Floating a => StateVector a -> a
+statePressure :: (Floating a, Ord a) => StateVector a -> a
 statePressure = heightToPressure . negate . (^._z) . nedToVec3 . statePos
 
 -- | Compute the true air-speed of the sensor platform. Useful as a


### PR DESCRIPTION
I'm not sure if you want this change because of the new dependency, but these are the changes that would be required to use the `atmos` library.

Because it models higher parts of the standard atmosphere, which is broken into layers, it needs to perform comparison operations on the numerical type. So this change introduces an `Ord a` context on all the pressures/heights. I don't know if this is tolerable by your symbolic evaluator/Ivory compiler.

An advantage of the change is that it extends correctness above 11km. Another is that the atmos package comes with unit tests checking it against tabulated results from the published standard atmosphere.

Taking this dependency might later be helpful to other parts of your autopilot code, since it also calculates standard temperatures, densities, speeds of sound, and dynamic/kinematic viscosities.
