### PR TITLE
Allow later versions of linear package.

### DIFF
--- a/estimator.cabal
+++ b/estimator.cabal
@@ -53,7 +53,7 @@ library
                        ad >=4.2,
                        distributive >=0.4,
                        lens >=4.6,
-                       linear >=1.16 && <1.17,
+                       linear >=1.16 && <1.19,
                        reflection >=1.5
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Numeric/Estimator/Augment.hs
+++ b/src/Numeric/Estimator/Augment.hs
@@ -26,6 +26,7 @@ import Data.Foldable
 import Data.Traversable
 import Linear
 import Numeric.Estimator.Class
+import Prelude
 
 -- | Holder for the basic state vector plus the augmented extra state.
 data AugmentState state extra a = AugmentState { getState :: state a, getExtra :: extra a }

--- a/src/Numeric/Estimator/KalmanFilter.hs
+++ b/src/Numeric/Estimator/KalmanFilter.hs
@@ -18,6 +18,7 @@ import Numeric.AD.Internal.Reverse (Tape)
 import Numeric.AD.Mode.Reverse
 import Numeric.Estimator.Class
 import Numeric.Estimator.Matrix
+import Prelude
 
 -- | All variants of Kalman Filter, at their core, maintain the
 -- parameters of a multi-variate normal distribution.

--- a/src/Numeric/Estimator/Model/Coordinate.hs
+++ b/src/Numeric/Estimator/Model/Coordinate.hs
@@ -21,6 +21,7 @@ import Data.Distributive
 import Data.Foldable
 import Data.Traversable
 import Linear
+import Prelude
 
 -- * Navigation frame
 


### PR DESCRIPTION
This version of `linear` works with the version of `base` that comes with GHC 7.10.
Also silenced the FTP/AMP warnings using a trick described in [the migration guide](https://ghc.haskell.org/trac/ghc/wiki/Migration/7.10).